### PR TITLE
Correct the VERSION variable setting

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ checksum: {}
 builds:
   - binary: pennywise
     ldflags:
-      - -s -w -X cmd/predef.VERSION={{ .Version }}
+      - -s -w -X github.com/kaytu-io/pennywise/cmd/predef.VERSION={{ .Version }}
     goos:
       - linux
       - darwin


### PR DESCRIPTION
Change the VERSION variable package so the Go Releaser can set it correctly.